### PR TITLE
Modify game over to wait for user

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
 Initial version of Mario-themed Snake game using pygame.
 
 Added exception handling for missing sprite files to prevent crash when images are absent.
+
+Enhanced game-over logic to keep the window open until the player closes it, allowing the Game Over screen to persist rather than exiting automatically.

--- a/game.py
+++ b/game.py
@@ -124,5 +124,13 @@ font_big = pygame.font.SysFont(None, 48)
 go_surf = font_big.render("Game Over", True, (255,0,0))
 screen.blit(go_surf, (SCREEN_WIDTH//2 - go_surf.get_width()//2, SCREEN_HEIGHT//2))
 pygame.display.flip()
-pygame.time.wait(2000)
+
+# Wait until player closes the window
+waiting = True
+while waiting:
+    for evt in pygame.event.get():
+        if evt.type == pygame.QUIT:
+            waiting = False
+    clock.tick(5)
+
 pygame.quit()


### PR DESCRIPTION
## Summary
- hold the window open when the player dies
- update changelog

## Testing
- `python -m py_compile game.py`

------
https://chatgpt.com/codex/tasks/task_b_6847579d8c1083299a9c194034477856